### PR TITLE
fix: Dependabot alertsの脆弱性を修正（flatted, undici）

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,11 @@
       "npm run fix"
     ]
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "pnpm": {
+    "overrides": {
+      "flatted": ">=3.4.2",
+      "undici": ">=7.24.0"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  flatted: '>=3.4.2'
+  undici: '>=7.24.0'
+
 importers:
 
   .:
@@ -1079,8 +1083,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.1:
-    resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -1987,10 +1991,6 @@ packages:
   undici-types@7.22.0:
     resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
-  undici@7.18.2:
-    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.24.7:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
@@ -2826,7 +2826,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.18.2
+      undici: 7.24.7
       whatwg-mimetype: 4.0.0
 
   cli-cursor@5.0.0:
@@ -3314,10 +3314,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.1: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.3:
     dependencies:
@@ -3989,7 +3989,7 @@ snapshots:
       chardet: 2.1.1
       cheerio: 1.1.2
       iconv-lite: 0.7.2
-      undici: 7.18.2
+      undici: 7.24.7
 
   optionator@0.9.3:
     dependencies:
@@ -4522,8 +4522,6 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici-types@7.22.0: {}
-
-  undici@7.18.2: {}
 
   undici@7.24.7: {}
 


### PR DESCRIPTION
## 概要

Dependabot alertsで検出された脆弱性7件を、`pnpm overrides`を使用して修正します。

## 修正内容

### flatted (alert #48)
- **脆弱性**: Prototype Pollution via parse() in NodeJS flatted
- **深刻度**: high
- **修正**: 3.3.1 → 3.4.2
- **経路**: eslint → file-entry-cache → flat-cache → flatted

### undici (alerts #42〜#47)
- **脆弱性**:
  - #47: Unbounded Memory Consumption in WebSocket (high)
  - #46: Unhandled Exception in WebSocket Client (high)
  - #45: CRLF Injection via `upgrade` option (medium)
  - #44: Unbounded Memory Consumption in DeduplicationHandler (medium)
  - #43: Malicious WebSocket 64-bit length overflows (high)
  - #42: HTTP Request/Response Smuggling (medium)
- **修正**: 7.18.2 → 7.24.7
- **経路**: open-graph-scraper → cheerio → undici

## 修正方法

間接依存のため、`package.json`に`pnpm.overrides`を追加して最小パッチバージョン以上を強制しています。

## テスト結果

- ✅ `pnpm test:ci` - 全テストパス
- ✅ `pnpm build` - ビルド成功