### PR TITLE
package.jsonにfilesフィールドを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.9",
   "description": "Remark plugin to convert link to bookmark component",
   "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "dependencies": {
     "@types/mdast": "4.0.4",


### PR DESCRIPTION
## 概要

`package.json` に `files` フィールドを追加し、npm publish時に配布するファイルを明示的に指定する。

## 変更内容

- `package.json`: `"files": ["dist"]` を追加

## 効果

**Before**: `.tagpr` など不要なファイルがパッケージに含まれていた
**After**: `dist/`, `LICENSE.txt`, `README.md`, `package.json` のみに限定

## テストプラン

- [ ] `pnpm pack --dry-run` で意図したファイルのみ含まれることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)