### PR TITLE
chore(deps): update pnpm to v11 (fix CI build-script approval)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
       "npm run fix"
     ]
   },
-  "packageManager": "pnpm@10.34.1+sha512.b58fbde6dca66a929538021581f648b4570b6ca19b18e7cbd7f2c07a7b24454155388dacdf08f2af3678e88a6d1fe04f9d609df24bf51735a060ea041b374ab7"
+  "packageManager": "pnpm@11.5.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## 概要

[#390](https://github.com/sota1235/remark-link-bookmark/pull/390)（pnpm v11 への更新）の CI fail を修正したものです。pnpm v11 への bump に加えて、CI が green になるよう build script の承認設定を追加しています。#390 はこの PR に置き換えてクローズできます。

## CI fail の原因

`check-code-quality` ジョブの `pnpm i` ステップが以下で失敗していました。

```
$ husky
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.7

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
##[error]Process completed with exit code 1.
```

pnpm v11 では、依存パッケージの build script が「承認」も「無視」もされていない場合、`pnpm i` が `ERR_PNPM_IGNORED_BUILDS` でエラー終了（exit 1）するように挙動が変わりました。`esbuild`（Vitest の transitive な build 依存）の build script が未承認のため CI が落ちていました。

また pnpm v11 ではこの承認設定の読み取り元が変わっており、`package.json` の `pnpm.onlyBuiltDependencies` フィールドは参照されず、`pnpm-workspace.yaml` の `allowBuilds` マップを使う必要があります。

## 修正内容

`pnpm-workspace.yaml` を追加し、esbuild の build script を承認しました。

```yaml
allowBuilds:
  esbuild: true
```

## 動作確認

ローカルで pnpm v11.5.0 を使い、CI の `check-code-quality` ジョブと同じ手順がすべて成功することを確認済みです。

- `pnpm i` → exit 0（`ERR_PNPM_IGNORED_BUILDS` が解消）
- `pnpm run build` → exit 0
- `pnpm run lint` → exit 0
- `pnpm run test:ci` → 1 passed

https://claude.ai/code/session_018kzhwm7ZLRcEqY7JV9sDvX

---
_Generated by [Claude Code](https://claude.ai/code/session_018kzhwm7ZLRcEqY7JV9sDvX)_