### PR TITLE
chore: pnpmのrenovate updateをchangelogから除外する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,18 @@
   ],
   "labels": [
     "kind/dependencies"
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": [
+        "pnpm"
+      ],
+      "matchDepTypes": [
+        "packageManager"
+      ],
+      "addLabels": [
+        "skip-changelog"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
renovateによるpnpm (packageManager) の更新PRに skip-changelog ラベルを
付与し、tagprが生成するchangelogに含まれないようにする。

pnpm updateは package.json の packageManager フィールドのみを変更するため、
ファイルベースのlabelerでは skip-changelog が付与されず、changelogに
含まれてしまっていた。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013jzBTHfroJwZTRmap2mNin